### PR TITLE
Revert "[DPS-154] Parse schema as map"

### DIFF
--- a/cmd/data-structure.go
+++ b/cmd/data-structure.go
@@ -38,6 +38,6 @@ type DataStructureSelf struct {
 
 type DataStrucutreData struct {
 	Self   DataStructureSelf `mapstructure:"self"`
-	Schema map[string]any    `mapstructure:"schema"`
+	Schema string            `mapstructure:"schema"`
 	Other  map[string]any    `mapstructure:",remain"`
 }

--- a/cmd/data-structure_test.go
+++ b/cmd/data-structure_test.go
@@ -29,7 +29,7 @@ func TestDataStructureJsonParseSuccess(t *testing.T) {
           "format": "string",
           "version": "1-0-1"
         },
-        "schema": {}
+        "schema": "string"
       }
     }`)
 	expected := DataStructure{
@@ -46,7 +46,7 @@ func TestDataStructureJsonParseSuccess(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	res := DataStructure{}
 	err := json.Unmarshal([]byte(jsonString), &res)
@@ -138,7 +138,7 @@ func TestParseDataParses(t *testing.T) {
 				"format":  "string",
 				"version": "1-2-0",
 			},
-			"schema":                map[string]any{},
+			"schema":                "string",
 			"additionalPropperties": false},
 	}
 	expected := DataStrucutreData{
@@ -148,7 +148,7 @@ func TestParseDataParses(t *testing.T) {
 			Format:  "string",
 			Version: "1-2-0",
 		},
-		Schema: map[string]any{},
+		Schema: "string",
 		Other: map[string]any{
 			"additionalPropperties": false,
 		},

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -15,7 +15,7 @@ func Test_ShowsDifferenceInMetadata(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	localDs := DataStructure{
 		Meta: DataStructureMeta{Hidden: true, SchemaType: "event"},
@@ -26,7 +26,7 @@ func Test_ShowsDifferenceInMetadata(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	diff, err := DiffDs([]DataStructure{localDs}, []DataStructure{remoteDs})
@@ -54,7 +54,7 @@ func Test_ShowsDifferenceInMetadataKnownField(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	localDs := DataStructure{
 		Meta: DataStructureMeta{Hidden: true, SchemaType: "entity", CustomData: map[string]string{
@@ -67,7 +67,7 @@ func Test_ShowsDifferenceInMetadataKnownField(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	diff, err := DiffDs([]DataStructure{localDs}, []DataStructure{remoteDs})
@@ -96,7 +96,7 @@ func Test_ShowDifferenceInMetadataUnknownField(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	localDs := DataStructure{
 		Meta: DataStructureMeta{Hidden: true, SchemaType: "entity", CustomData: map[string]string{
@@ -109,7 +109,7 @@ func Test_ShowDifferenceInMetadataUnknownField(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	diff, err := DiffDs([]DataStructure{localDs}, []DataStructure{remoteDs})
@@ -138,7 +138,7 @@ func Test_ShowDifferenceInSchemaSelf(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	localDs := DataStructure{
 		Meta: DataStructureMeta{Hidden: true, SchemaType: "entity"},
@@ -149,7 +149,7 @@ func Test_ShowDifferenceInSchemaSelf(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-2",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	diff, err := DiffDs([]DataStructure{localDs}, []DataStructure{remoteDs})
@@ -178,7 +178,7 @@ func Test_ShowDifferenceInSchema(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	localDs := DataStructure{
 		Meta: DataStructureMeta{Hidden: true, SchemaType: "entity"},
@@ -189,7 +189,7 @@ func Test_ShowDifferenceInSchema(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{"test": "test"}},
+			"schema": `{"test": "test"}`},
 	}
 
 	diff, err := DiffDs([]DataStructure{localDs}, []DataStructure{remoteDs})
@@ -202,7 +202,7 @@ func Test_ShowDifferenceInSchema(t *testing.T) {
 		t.Fatalf("Not expected amount of changes, expected: 1, got: %d", len(diff))
 	}
 
-	if !reflect.DeepEqual(diff[0].Diff[0].Path, []string{"Data", "schema", "test"}) {
+	if !reflect.DeepEqual(diff[0].Diff[0].Path, []string{"Data", "schema"}) {
 		t.Fatalf("Not expected change path, %v", diff[0].Diff[0].Path)
 	}
 

--- a/cmd/files_test.go
+++ b/cmd/files_test.go
@@ -25,7 +25,7 @@ func TestCreatesDataStructuresFolderWithFiles(t *testing.T) {
 				"format":  "string",
 				"version": "1-2-0",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	vendor2 := "com.test.vendor"
 	name2 := "ds2"
@@ -43,7 +43,7 @@ func TestCreatesDataStructuresFolderWithFiles(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	dir := filepath.Join("..", "out", "test-ds2")
@@ -88,7 +88,7 @@ func TestCreatesDataStructuresFolderWithFilesJson(t *testing.T) {
 				"format":  "string",
 				"version": "1-2-0",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 	vendor2 := "com.test.vendor"
 	name2 := "ds2"
@@ -106,7 +106,7 @@ func TestCreatesDataStructuresFolderWithFilesJson(t *testing.T) {
 				"format":  "string",
 				"version": "1-0-1",
 			},
-			"schema": map[string]any{}},
+			"schema": "string"},
 	}
 
 	dir := filepath.Join("..", "out", "test-ds2")


### PR DESCRIPTION
I've had a brainfart, and thought that `schema` contained the schema, and not the URI or schema