### PR TITLE
[DPS-169] Configs and flags for console specific cmds

### DIFF
--- a/cmd/console_config.go
+++ b/cmd/console_config.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func InitConsoleFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringP("api-key", "a", "", "BDP console api key")
+	cmd.PersistentFlags().StringP("host", "H", "https://console.snowplowanalytics.com", "BDP console host")
+	cmd.PersistentFlags().StringP("org-id", "o", "", "Your organization id")
+}
+
+func InitConsoleConfig(cmd *cobra.Command) error {
+	v := viper.New()
+	if cfgFile != "" {
+		v.SetConfigFile(cfgFile)
+	} else {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+
+		v.AddConfigPath(home)
+		v.AddConfigPath("$XDG_CONFIG_HOME/snowplow")
+		v.SetConfigName(".snowplow")
+	}
+
+	v.SetEnvPrefix("SNOWPLOW_CONSOLE")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.AutomaticEnv()
+
+	if err := v.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", v.ConfigFileUsed())
+	}
+
+	err := populateCmdConsoleConfigFlags(cmd, v)
+	if err != nil {
+		return err
+	}
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			cmd.Flags().Set(f.Name, fmt.Sprintf("%s", v.Get(f.Name)))
+		}
+	})
+
+	return nil
+}
+
+func populateCmdConsoleConfigFlags(cmd *cobra.Command, v *viper.Viper) error {
+	if !v.IsSet("console") {
+		return nil
+	}
+
+	m, ok := v.Get("console").(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("console config file key parse failure, got: %v", v.Get("console"))
+	}
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if value, ok := m[f.Name]; !f.Changed && ok {
+			cmd.Flags().Set(f.Name, fmt.Sprintf("%s", value))
+		}
+	})
+	return nil
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -47,10 +47,14 @@ to quickly create a Cobra application.`,
 		files.createDataStructures(dss)
 
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return InitConsoleConfig(cmd)
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(importCmd)
+	InitConsoleFlags(importCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,9 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var cfgFile string
@@ -23,9 +21,6 @@ examples and usage of using your application. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -38,45 +33,8 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (defaults to $HOME/.snowplow.{yaml|json|toml} \nthen $XDG_CONFIG_HOME/snowplow/.snowplow.{yaml|json|toml})")
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dps-cli.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-	rootCmd.PersistentFlags().StringP("api-key", "a", "", "BDP console api key")
-	rootCmd.PersistentFlags().StringP("host", "H", "console.snowplowanalytics.com", "BDP console host")
-	rootCmd.PersistentFlags().StringP("org-id", "o", "", "Your organization id")
 	rootCmd.PersistentFlags().StringP("data-structures", "d", "data-structures", "Data structures directory name")
 	rootCmd.PersistentFlags().StringP("format", "f", "yaml", "Format of the files to read/write. json or yaml are supported")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".dps-cli" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".dps-cli")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,18 +22,12 @@ to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("sync called")
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return InitConsoleConfig(cmd)
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(syncCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// syncCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// syncCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	InitConsoleFlags(syncCmd)
 }


### PR DESCRIPTION
The binding things between viper and cobra just don't seem to work with default flag values. So I'm cheating and just merging by hand.

The config expects toml|yaml|json in this shape:
```
[console]
host="https://sdfs"
api-key=""
org-id=""
```

Should probably make sure this works on windows too. Well, at least doesn't explode.

I've no clue how to test this sensibly.

