### PR TITLE
Update unexpected compatibility check error to use pathError (#88)

### DIFF
--- a/internal/validation/local_data_product_validation.go
+++ b/internal/validation/local_data_product_validation.go
@@ -70,8 +70,9 @@ func ValidateDPEventSpecCompat(cc console.CompatChecker, dp model.DataProduct) D
 
 		result, err := cc(*event, entities)
 		if err != nil {
-			errors = append(
-				errors,
+			path := fmt.Sprintf("/data/eventSpecifications/%d", i)
+			pathErrors[path] = append(
+				pathErrors[path],
 				fmt.Sprintf("unexpected error checking compatibility got: %s", err.Error()),
 			)
 			continue


### PR DESCRIPTION
When an unexpected compatibility error occurs, use a pathError instead of a regular error in order to provide the user with the event specification path that the error occurred on.

The output now looks like this, and includes the `path=` for the error:

![image](https://github.com/user-attachments/assets/e11d7230-76bb-4fbf-8ab7-efc1978b4943)

Relates to #88 
