### PR TITLE
Use semaphore to parallelize data product validation

### DIFF
--- a/cmd/dp/validate.go
+++ b/cmd/dp/validate.go
@@ -38,12 +38,23 @@ var validateCmd = &cobra.Command{
 		org, _ := cmd.Flags().GetString("org-id")
 		ghOut, _ := cmd.Flags().GetBool("gh-annotate")
 		full, _ := cmd.Flags().GetBool("full")
+		concurrentReq, _ := cmd.Flags().GetInt("concurrency")
 
 		searchPaths := []string{}
 
 		if len(args) == 0 {
 			searchPaths = append(searchPaths, util.DataProductsFolder)
 			slog.Debug("validation", "msg", fmt.Sprintf("no path provided, using default (./%s)", util.DataProductsFolder))
+		}
+
+		if concurrentReq > 10 {
+			concurrentReq = 10
+			slog.Debug("validation", "msg", "concurrency set to > 10, limited to 10")
+		}
+
+		if concurrentReq < 1 {
+			concurrentReq = 1
+			slog.Debug("validation", "msg", "concurrency set to < 1, increased to 1")
 		}
 
 		searchPaths = append(searchPaths, args...)
@@ -70,7 +81,7 @@ var validateCmd = &cobra.Command{
 			snplog.LogFatal(err)
 		}
 
-		validation.Validate(cnx, c, files, searchPaths, basePath, ghOut, full, changes.IdToFileName)
+		validation.Validate(cnx, c, files, searchPaths, basePath, ghOut, full, changes.IdToFileName, concurrentReq)
 	},
 }
 
@@ -79,4 +90,5 @@ func init() {
 
 	validateCmd.PersistentFlags().Bool("gh-annotate", false, "Output suitable for github workflow annotation (ignores -s)")
 	validateCmd.PersistentFlags().Bool("full", false, "Perform compatibility check on all files, not only the ones that were changed")
+	validateCmd.PersistentFlags().IntP("concurrency", "c", 3, "The number of validation requests to perform at once (maximum 10)")
 }

--- a/internal/validation/local_data_product_validation.go
+++ b/internal/validation/local_data_product_validation.go
@@ -26,7 +26,7 @@ type result struct {
 	pathLookup map[string]string
 }
 
-func ValidateDPEventSpecCompat(cc console.CompatChecker, dp model.DataProduct) DPValidations {
+func ValidateDPEventSpecCompat(cc console.CompatChecker, concurrency int, dp model.DataProduct) DPValidations {
 	pathErrors := map[string][]string{}
 	pathWarnings := map[string][]string{}
 	errors := []string{}
@@ -34,7 +34,7 @@ func ValidateDPEventSpecCompat(cc console.CompatChecker, dp model.DataProduct) D
 	resultsChan := make(chan result)
 
 	var wg sync.WaitGroup
-	semaphore := make(chan struct{}, 3) // Semaphore for 3x parallelism
+	semaphore := make(chan struct{}, concurrency)
 
 	for i, spec := range dp.Data.EventSpecifications {
 		var event *console.CompatCheckable

--- a/internal/validation/local_data_product_validation_test.go
+++ b/internal/validation/local_data_product_validation_test.go
@@ -51,7 +51,7 @@ func Test_ValidateDPEventSpecCompatOk(t *testing.T) {
 		return &console.CompatResult{Status: "compatible"}, nil
 	}
 
-	result := ValidateDPEventSpecCompat(cc, dp)
+	result := ValidateDPEventSpecCompat(cc, 1, dp)
 
 	if len(result.Errors) > 0 || len(result.Warnings) > 0 {
 		t.Fatal("unexpected failures")
@@ -62,7 +62,7 @@ func Test_ValidateDPEventSpecCompatMissingEvent(t *testing.T) {
 	dp := newValidDPForCompatTesting()
 	dp.Data.EventSpecifications[0].Event = model.SchemaRef{}
 
-	result := ValidateDPEventSpecCompat(nil, dp).WarningsWithPaths
+	result := ValidateDPEventSpecCompat(nil, 1, dp).WarningsWithPaths
 
 	expectPath := "/data/eventSpecifications/0"
 	expectValue := []string{"will not run compatibility check without an event defined"}
@@ -98,7 +98,7 @@ func Test_ValidateDPEventSpecCompatFail(t *testing.T) {
 		}, nil
 	}
 
-	result := ValidateDPEventSpecCompat(cc, dp)
+	result := ValidateDPEventSpecCompat(cc, 2, dp)
 
 	expectedErrorPaths := []string{
 		"/data/eventSpecifications/0/event/schema/key",

--- a/internal/validation/local_dp_validation.go
+++ b/internal/validation/local_dp_validation.go
@@ -63,7 +63,7 @@ func (v *DPValidations) concat(r DPValidations) {
 	}
 }
 
-func NewDPLookup(cc console.CompatChecker, sdc console.SchemaDeployChecker, dp map[string]map[string]any, changedIdToFile map[string]string, validateAll bool) (*DPLookup, error) {
+func NewDPLookup(cc console.CompatChecker, sdc console.SchemaDeployChecker, dp map[string]map[string]any, changedIdToFile map[string]string, validateAll bool, concurrency int) (*DPLookup, error) {
 
 	probablyDps := map[string]model.DataProduct{}
 	probablySap := map[string]model.SourceApp{}
@@ -97,10 +97,10 @@ func NewDPLookup(cc console.CompatChecker, sdc console.SchemaDeployChecker, dp m
 				changed := changedFiles[f]
 				if ok {
 					if validateAll {
-						v.concat(ValidateDPEventSpecCompat(cc, dp))
+						v.concat(ValidateDPEventSpecCompat(cc, concurrency, dp))
 					} else {
 						if changed {
-							v.concat(ValidateDPEventSpecCompat(cc, dp))
+							v.concat(ValidateDPEventSpecCompat(cc, concurrency, dp))
 						} else {
 							v.Debug = append(v.Debug, fmt.Sprintf("skipping compatibility check for %s, since it was not changed, use --full to include it in validation", f))
 						}

--- a/internal/validation/local_dp_validation_test.go
+++ b/internal/validation/local_dp_validation_test.go
@@ -36,7 +36,7 @@ func Test_DPLookup_RelativePaths(t *testing.T) {
 		},
 	}
 
-	lookup, err := NewDPLookup(nil, nil, input, nil, true)
+	lookup, err := NewDPLookup(nil, nil, input, nil, true, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func Test_DPLookup_EventSpecBadSourceApp(t *testing.T) {
 		},
 	}
 
-	lookup, err := NewDPLookup(nil, nil, input, nil, true)
+	lookup, err := NewDPLookup(nil, nil, input, nil, true, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func Test_DPLookup_Resolved(t *testing.T) {
 		},
 	}
 
-	lookup, err := NewDPLookup(nil, nil, input, nil, true)
+	lookup, err := NewDPLookup(nil, nil, input, nil, true, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func Test_DPLookup_Ignored(t *testing.T) {
 		},
 	}
 
-	lookup, err := NewDPLookup(nil, nil, input, nil, true)
+	lookup, err := NewDPLookup(nil, nil, input, nil, true, 1)
 
 	if err != nil {
 		t.Fatal(err)

--- a/internal/validation/logic_dp.go
+++ b/internal/validation/logic_dp.go
@@ -19,7 +19,7 @@ import (
 	snplog "github.com/snowplow/snowplow-cli/internal/logging"
 )
 
-func Validate(cnx context.Context, c *console.ApiClient, files map[string]map[string]any, searchPaths []string, basePath string, ghOut bool, validateAll bool, changedIdToFile map[string]string) {
+func Validate(cnx context.Context, c *console.ApiClient, files map[string]map[string]any, searchPaths []string, basePath string, ghOut bool, validateAll bool, changedIdToFile map[string]string, concurrency int) {
 	possibleFiles := []string{}
 	for n := range files {
 		possibleFiles = append(possibleFiles, n)
@@ -34,7 +34,7 @@ func Validate(cnx context.Context, c *console.ApiClient, files map[string]map[st
 		return console.CompatCheck(cnx, c, event, entities)
 	}
 
-	lookup, err := NewDPLookup(compatChecker, schemaResolver, files, changedIdToFile, validateAll)
+	lookup, err := NewDPLookup(compatChecker, schemaResolver, files, changedIdToFile, validateAll, concurrency)
 	if err != nil {
 		snplog.LogFatal(err)
 	}


### PR DESCRIPTION
This PR updates `snowplow-cli data-product validate` and `snowplow-cli data-product publish` to use a threaded approach to send event specification compatibility checks to the validation API. This is currently implemented with 10 threads, and has been tested on validation and upload of a collection of data products containing 300+ event specifications.

Relates to #90