### PR TITLE
Ensure prod dry-run catches patching error

### DIFF
--- a/cmd/ds/publish.go
+++ b/cmd/ds/publish.go
@@ -110,7 +110,9 @@ Changes to it will be published by this command.
 			LogFatal(errors.New(vr.Message))
 		}
 
-		if !dryRun {
+		if dryRun {
+			slog.Info("dry run, not performing changes")
+		} else {
 			err = changesPkg.PerformChangesDev(cnx, c, changes, managedFrom)
 			if err != nil {
 				LogFatal(err)
@@ -180,13 +182,16 @@ environment will be published to your production environment.
 		if err != nil {
 			LogFatal(err)
 		}
-		if !dryRun {
+		if dryRun {
+			slog.Info("dry run, not performing changes")
+			err = changesPkg.ValidateChangesProd(cnx, c, changes, managedFrom)
+		} else {
 			err = changesPkg.PerformChangesProd(cnx, c, changes, managedFrom)
-			if err != nil {
-				LogFatal(err)
-			}
-			slog.Info("all done!")
 		}
+		if err != nil {
+			LogFatal(err)
+		}
+		slog.Info("all done!")
 	},
 }
 

--- a/internal/changes/changes.go
+++ b/internal/changes/changes.go
@@ -157,9 +157,17 @@ func PerformChangesDev(cnx context.Context, c *ApiClient, changes Changes, manag
 	return nil
 }
 
-func PerformChangesProd(cnx context.Context, c *ApiClient, changes Changes, managedFrom string) error {
+func ValidateChangesProd(cnx context.Context, c *ApiClient, changes Changes, managedFrom string) error {
 	if len(changes.ToUpdatePatch) != 0 {
 		return errors.New("patching is not available on prod. You must increment versions on dev before deploying")
+	}
+	return nil
+}
+
+func PerformChangesProd(cnx context.Context, c *ApiClient, changes Changes, managedFrom string) error {
+	err := ValidateChangesProd(cnx, c, changes, managedFrom)
+	if err != nil {
+		return err
 	}
 	validatePublish := append(changes.ToCreate, changes.ToUpdateNewVersion...)
 	for _, ds := range validatePublish {


### PR DESCRIPTION
Ensure that using `--dry-run` option on `data-structures publish prod` catches situations where patching is present, and cannot be published to prod.

Additionally, include a logging message to confirm that `--dry-run` option is being used for both dev and prod publishing.

Resolves #93.