### PR TITLE
[DPS-1241] Cursor work around and custom header + prompt update

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -80,6 +81,17 @@ event_completeness_checklist: |
   - focus_form, change_form, submit_form (if tracking forms)
   - screen_view (if tracking mobile apps)
   - link_click (if tracking navigation)
+
+canonical_property_shadowing_policy: |
+  Do NOT define custom fields in data structures that duplicate or conflict with Snowplow’s canonical (out-of-the-box) event properties
+  (e.g., collector_tstamp, user_id, app_id, page_url, etc.).
+  Exception:
+    - The provided 'page_view' and 'page_ping' schemas are intended for use in event specifications.
+    - These schemas are derived from canonical events and should be referenced in event specifications as needed.
+    - Do NOT redefine or duplicate these schema as custom data structures.
+  Rationale:
+    Shadowing canonical properties can cause confusion, data quality issues, and make downstream analytics more difficult.
+    The exception for 'page_view' and 'page_ping' ensures event specifications can use standard event types for consistency.
 
 implementation_pattern_emphasis: |
   Standard Pattern for Data Products:
@@ -200,15 +212,22 @@ var McpCmd = &cobra.Command{
     }
   }
 
-  VS Code:
+  VS Code '.vscode/mcp.json':
   {
-    "mcp": {
+    "servers": {
       ...
-      "servers": {
-        ...
-        "snowplow-cli": {
-          "command": "snowplow-cli", "args": ["mcp"]
-        }
+      "snowplow-cli": {
+        "command": "snowplow-cli", "args": ["mcp"]
+      }
+    }
+  }
+
+  Cursor '.cursor/mcp.json':
+  {
+    "servers": {
+      ...
+      "snowplow-cli": {
+        "command": "snowplow-cli", "args": ["mcp", "--base-directory", "."]
       }
     }
   }
@@ -236,6 +255,7 @@ func init() {
 	config.InitConsoleFlags(McpCmd)
 
 	McpCmd.Flags().Bool("dump-context", false, "Dumps the result of the get_context tool to stdout and exits.")
+	McpCmd.Flags().String("base-directory", "", "The base path to use for relative file lookups. Useful for clients that pass in relative file paths.")
 }
 
 func runMCPServer(cmd *cobra.Command, args []string) error {
@@ -305,7 +325,7 @@ func genUuid(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolRes
 	return mcp.NewToolResultText(strings.Join(result, ", ")), nil
 }
 
-func pathsFromArguments(args map[string]any) ([]string, error) {
+func pathsFromArguments(base string, args map[string]any) ([]string, error) {
 	paths, ok := args["paths"].([]any)
 	if !ok {
 		return nil, errors.New("file_path must be strings")
@@ -314,7 +334,7 @@ func pathsFromArguments(args map[string]any) ([]string, error) {
 	filePaths := []string{}
 	for _, p := range paths {
 		if fp, ok := p.(string); ok {
-			filePaths = append(filePaths, fp)
+			filePaths = append(filePaths, filepath.Join(base, fp))
 		}
 	}
 
@@ -329,10 +349,14 @@ func validateDataProductsHandler(cmd *cobra.Command) server.ToolHandlerFunc {
 		logLevel = slog.LevelDebug
 	}
 
+	baseDir, _ := cmd.Flags().GetString("base-directory")
+
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ctx = context.WithValue(ctx, util.MCPSourceContextKey{}, true)
+
 		args := request.GetArguments()
 
-		paths, err := pathsFromArguments(args)
+		paths, err := pathsFromArguments(baseDir, args)
 		if err != nil {
 			return nil, errors.New("file_path must be strings")
 		}
@@ -367,10 +391,14 @@ func validateDataStructuresHandler(cmd *cobra.Command) server.ToolHandlerFunc {
 		logLevel = slog.LevelDebug
 	}
 
+	baseDir, _ := cmd.Flags().GetString("base-directory")
+
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ctx = context.WithValue(ctx, util.MCPSourceContextKey{}, true)
+
 		args := request.GetArguments()
 
-		paths, err := pathsFromArguments(args)
+		paths, err := pathsFromArguments(baseDir, args)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/console/requests_ds.go
+++ b/internal/console/requests_ds.go
@@ -87,13 +87,11 @@ func Validate(cnx context.Context, client *ApiClient, ds model.DataStructure) (*
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(cnx, "POST", fmt.Sprintf("%s/data-structures/v1/validation-requests", client.BaseUrl), bytes.NewBuffer(body))
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return nil, err
 	}
+
+	addStandardHeaders(req, cnx, client)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return nil, err
@@ -162,9 +160,11 @@ func publish(cnx context.Context, client *ApiClient, from DataStructureEnv, to D
 		return nil, err
 	}
 	req, err := http.NewRequestWithContext(cnx, "POST", fmt.Sprintf("%s/data-structures/v1/deployment-requests", client.BaseUrl), bytes.NewBuffer(body))
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	addStandardHeaders(req, cnx, client)
 	if isPatch {
 		q := req.URL.Query()
 		q.Add("patch", "true")
@@ -208,12 +208,12 @@ type Deployment struct {
 }
 
 type ListResponse struct {
-	Hash        string            `json:"hash"`
-	Vendor      string            `json:"vendor"`
-	Format      string            `json:"format"`
-	Name        string            `json:"name"`
+	Hash        string                  `json:"hash"`
+	Vendor      string                  `json:"vendor"`
+	Format      string                  `json:"format"`
+	Name        string                  `json:"name"`
 	Meta        model.DataStructureMeta `json:"meta"`
-	Deployments []Deployment      `json:"deployments"`
+	Deployments []Deployment            `json:"deployments"`
 }
 
 func GetIgluCentralListing(cnx context.Context, client *ApiClient) ([]string, error) {
@@ -247,13 +247,11 @@ func GetIgluCentralListing(cnx context.Context, client *ApiClient) ([]string, er
 
 func GetDataStructureListing(cnx context.Context, client *ApiClient) ([]ListResponse, error) {
 	req, err := http.NewRequestWithContext(cnx, "GET", fmt.Sprintf("%s/data-structures/v1", client.BaseUrl), nil)
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return nil, err
 	}
+
+	addStandardHeaders(req, cnx, client)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return nil, err
@@ -278,13 +276,11 @@ func GetDataStructureListing(cnx context.Context, client *ApiClient) ([]ListResp
 
 func GetDataStructureDeployments(cnx context.Context, client *ApiClient, dsHash string) ([]Deployment, error) {
 	req, err := http.NewRequestWithContext(cnx, "GET", fmt.Sprintf("%s/data-structures/v1/%s/deployments?from=0&size=1000000000", client.BaseUrl, dsHash), nil)
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return nil, err
 	}
+
+	addStandardHeaders(req, cnx, client)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return nil, err
@@ -322,13 +318,11 @@ func GetAllDataStructures(cnx context.Context, client *ApiClient, match []string
 	var includedLegacyCount int
 
 	req, err := http.NewRequestWithContext(cnx, "GET", fmt.Sprintf("%s/data-structures/v1/schemas/versions?latest=true", client.BaseUrl), nil)
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return nil, err
 	}
+
+	addStandardHeaders(req, cnx, client)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return nil, err
@@ -440,13 +434,11 @@ func patchMeta(cnx context.Context, client *ApiClient, ds *model.DataStructureSe
 	}
 	url := fmt.Sprintf("%s/data-structures/v1/%x/meta", client.BaseUrl, dsHash)
 	req, err := http.NewRequestWithContext(cnx, "PATCH", url, bytes.NewBuffer(body))
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return err
 	}
+
+	addStandardHeaders(req, cnx, client)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {

--- a/internal/console/requests_img.go
+++ b/internal/console/requests_img.go
@@ -152,6 +152,9 @@ func uploadImage(cnx context.Context, client *ApiClient, fname string, uploadLin
 		return err
 	}
 	req.Header.Set("content-type", writer.FormDataContentType())
+
+	// Note: This is uploading to an external service (Cloudflare), not our API,
+	// so we don't add standard console headers here
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return err

--- a/internal/console/requests_migrations.go
+++ b/internal/console/requests_migrations.go
@@ -32,9 +32,9 @@ type apiError struct {
 }
 
 type migrationRequest struct {
-	DestinationType string            `json:"destinationType"`
+	DestinationType string                  `json:"destinationType"`
 	SourceSchemaKey model.DataStructureSelf `json:"sourceSchemaKey"`
-	TargetSchema    map[string]any    `json:"targetSchema"`
+	TargetSchema    map[string]any          `json:"targetSchema"`
 }
 
 type migrationResponse struct {
@@ -69,9 +69,7 @@ func fetchMigration(cnx context.Context, client *ApiClient, destination string, 
 		return nil, err
 	}
 
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
+	addStandardHeaders(req, cnx, client)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
@@ -103,13 +101,11 @@ func fetchMigration(cnx context.Context, client *ApiClient, destination string, 
 
 func fetchDestinations(cnx context.Context, client *ApiClient) ([]destination, error) {
 	req, err := http.NewRequestWithContext(cnx, "GET", fmt.Sprintf("%s/destinations/v3", client.BaseUrl), nil)
-	auth := fmt.Sprintf("Bearer %s", client.Jwt)
-	req.Header.Add("authorization", auth)
-	req.Header.Add("X-SNOWPLOW-CLI", util.VersionInfo)
-
 	if err != nil {
 		return nil, err
 	}
+
+	addStandardHeaders(req, cnx, client)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -24,14 +24,14 @@ import (
 type loggerKey struct{}
 
 func ContextWithLogger(ctx context.Context, logger *slog.Logger) context.Context {
-    return context.WithValue(ctx, loggerKey{}, logger)
+	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
 func LoggerFromContext(ctx context.Context) *slog.Logger {
-    if logger, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok {
-        return logger
-    }
-    return slog.Default()
+	if logger, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok {
+		return logger
+	}
+	return slog.Default()
 }
 
 func InitLogging(cmd *cobra.Command) error {

--- a/internal/model/data-structure_test.go
+++ b/internal/model/data-structure_test.go
@@ -151,7 +151,7 @@ func TestParseDataParses(t *testing.T) {
 				"format":  "string",
 				"version": "1-2-0",
 			},
-			"$schema":                "string",
+			"$schema":               "string",
 			"additionalPropperties": false},
 	}
 	expected := DataStructureData{

--- a/internal/publish/mappings_test.go
+++ b/internal/publish/mappings_test.go
@@ -245,8 +245,8 @@ func TestDpToDiff(t *testing.T) {
 
 func Test_saToDiff(t *testing.T) {
 	input := console.RemoteSourceApplication{
-		Id: "id",
-		LockStatus: "locked",
+		Id:          "id",
+		LockStatus:  "locked",
 		ManagedFrom: "somewhere",
 	}
 

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -20,3 +20,5 @@ const DataProductResourceType = "data-product"
 const SourceApplicationResourceType = "source-application"
 
 const RepoRawFileURL = "https://raw.githubusercontent.com/snowplow/snowplow-cli/refs/heads/main/internal/validation/schema/"
+
+type MCPSourceContextKey struct{}

--- a/internal/validation/local_data_product_shape_validation_test.go
+++ b/internal/validation/local_data_product_shape_validation_test.go
@@ -88,7 +88,7 @@ data:
 `
 
 var dpRulesTests = []struct {
-	in  string
+	in    string
 	valid bool
 }{
 	{`{ type: string }`, false},
@@ -112,7 +112,7 @@ func Test_ValidateDPShape_Rules(t *testing.T) {
 
 			_, ok := ValidateDPShape(input)
 
-			if ok != tt.valid { 
+			if ok != tt.valid {
 				t.Errorf("%s got: %v want: %v", tt.in, ok, tt.valid)
 			}
 		})

--- a/internal/validation/local_source_app_validation_test.go
+++ b/internal/validation/local_source_app_validation_test.go
@@ -18,8 +18,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-
-
 func Test_ValidateSAMinimum(t *testing.T) {
 	mvSa := `
 apiVersion: v1
@@ -74,7 +72,6 @@ data:
 		t.Fatal("expected errors at /data/name")
 	}
 }
-
 
 func Test_ValidateSAEntitesSourcesOk(t *testing.T) {
 	mvSa := `
@@ -204,7 +201,7 @@ func Test_ValidateSAEntitiesSchemaDeployed(t *testing.T) {
 
 	t.Log(result)
 
-	for _, p := range []string{ expectedOne, expectedTwo } {
+	for _, p := range []string{expectedOne, expectedTwo} {
 		if _, ok := result[p]; !ok {
 			t.Fatalf("expected errors at %s", p)
 		}


### PR DESCRIPTION
Cursor doesn't do absolute paths, so we have to work around. There is an env var they make available but there are complications there and this seems to work ok. We'll see.

The header is just so we can spot mcp based traffic.

The prompt update comes from internal testing (thanks Cian). chatgpt was adding timestamps to things it didn't need to.