### PR TITLE
DPS-1290 absolute paths and misc bits

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -244,7 +244,8 @@ Setup options:
 `,
 	RunE: runMCPServer,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := config.InitConsoleConfig(cmd); err != nil {
+		baseDir, _ := cmd.Flags().GetString("base-directory")
+		if err := config.InitConsoleConfigWithBaseDir(cmd, baseDir); err != nil {
 			logging.LogFatal(err)
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ type rawAppConfig struct {
 	Console map[string]string
 }
 
-func loadEnvFiles(cmd *cobra.Command) error {
+func loadEnvFiles(cmd *cobra.Command, baseDir string) error {
 	var envFilePaths []string
 	var isExplicitFile bool
 
@@ -44,9 +44,16 @@ func loadEnvFiles(cmd *cobra.Command) error {
 		envFilePaths = append(envFilePaths, envFile)
 		isExplicitFile = true
 	} else {
-		cwd, err := os.Getwd()
-		if err == nil {
-			envFilePaths = append(envFilePaths, filepath.Join(cwd, ".env"))
+		workingDir := baseDir
+		if workingDir == "" {
+			cwd, err := os.Getwd()
+			if err == nil {
+				workingDir = cwd
+			}
+		}
+
+		if workingDir != "" {
+			envFilePaths = append(envFilePaths, filepath.Join(workingDir, ".env"))
 		}
 
 		home, err := os.UserHomeDir()
@@ -83,8 +90,12 @@ func loadEnvFiles(cmd *cobra.Command) error {
 }
 
 func InitConsoleConfig(cmd *cobra.Command) error {
+	return InitConsoleConfigWithBaseDir(cmd, "")
+}
 
-	if err := loadEnvFiles(cmd); err != nil {
+func InitConsoleConfigWithBaseDir(cmd *cobra.Command, baseDir string) error {
+
+	if err := loadEnvFiles(cmd, baseDir); err != nil {
 		return fmt.Errorf("failed to load .env file: %w", err)
 	}
 

--- a/internal/download/mappings_test.go
+++ b/internal/download/mappings_test.go
@@ -165,6 +165,23 @@ func Test_localSasToRefs_OK(t *testing.T) {
 
 }
 
+func Test_localSasToRefs_AbsolutePath(t *testing.T) {
+	dpLocation := "/tmp/data-products"
+
+	fileNamesToLocalSas := map[string]model.CliResource[model.SourceAppData]{
+		"/tmp/data-products/source-apps/test.yaml": SaResource[0],
+	}
+	res, err := localSasToRefs(fileNamesToLocalSas, dpLocation)
+
+	expectedRefs := map[string]model.Ref{
+		sampleSa1.Id: {Ref: "./source-apps/test.yaml"},
+	}
+
+	if !reflect.DeepEqual(expectedRefs, res) || err != nil {
+		t.Errorf("localSasToRefs with absolute data products path '%s' should generate relative refs './source-apps/test.yaml', expected:%+v got:%+v, err:%s", dpLocation, expectedRefs, res, err)
+	}
+}
+
 func Test_remoteDpsToLocalResources_OK(t *testing.T) {
 	res := remoteDpsToLocalResources(sampleRemoteDps, sampleSaRefs2, sampleEsIdToEs, map[string]string{sampleRemoteTrigger.Id: "./images/test"})
 	expected := []model.CliResource[model.DataProductCanonicalData]{{

--- a/internal/util/files.go
+++ b/internal/util/files.go
@@ -130,7 +130,14 @@ func createUniqueNames(idsToFileNames []idFileName) []idFileName {
 }
 
 func (f Files) CreateSourceApps(sas []model.CliResource[model.SourceAppData], isPlain bool) (map[string]model.CliResource[model.SourceAppData], error) {
-	sourceAppsPath := filepath.Join(".", f.DataProductsLocation, f.SourceAppsLocation)
+	var dataProductsPath string
+	if filepath.IsAbs(f.DataProductsLocation) {
+		dataProductsPath = f.DataProductsLocation
+	} else {
+		dataProductsPath = filepath.Join(".", f.DataProductsLocation)
+	}
+
+	sourceAppsPath := filepath.Join(dataProductsPath, f.SourceAppsLocation)
 	err := os.MkdirAll(sourceAppsPath, os.ModePerm)
 
 	if err != nil {
@@ -161,7 +168,13 @@ func (f Files) CreateSourceApps(sas []model.CliResource[model.SourceAppData], is
 }
 
 func (f Files) CreateDataProducts(dps []model.CliResource[model.DataProductCanonicalData], isPlain bool) (map[string]model.CliResource[model.DataProductCanonicalData], error) {
-	dataProductsPath := filepath.Join(".", f.DataProductsLocation)
+	var dataProductsPath string
+	if filepath.IsAbs(f.DataProductsLocation) {
+		dataProductsPath = f.DataProductsLocation
+	} else {
+		dataProductsPath = filepath.Join(".", f.DataProductsLocation)
+	}
+
 	err := os.MkdirAll(dataProductsPath, os.ModePerm)
 
 	if err != nil {
@@ -192,23 +205,25 @@ func (f Files) CreateDataProducts(dps []model.CliResource[model.DataProductCanon
 }
 
 func (f Files) CreateImageFolder() (string, error) {
-	cwd, err := os.Getwd()
+	var dataProductsPath string
+	if filepath.IsAbs(f.DataProductsLocation) {
+		dataProductsPath = f.DataProductsLocation
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		dataProductsPath = filepath.Join(cwd, f.DataProductsLocation)
+	}
+
+	imagesPath := filepath.Join(dataProductsPath, f.ImagesLocation)
+	err := os.MkdirAll(imagesPath, os.ModePerm)
+
 	if err != nil {
 		return "", err
 	}
 
-	imagesPath := filepath.Join(cwd, f.DataProductsLocation, f.ImagesLocation)
-	err = os.MkdirAll(imagesPath, os.ModePerm)
-
-	if err != nil {
-		return "", err
-	}
-
-	relativePath, err := filepath.Rel(cwd, imagesPath)
-	if err != nil {
-		return "", err
-	}
-	return relativePath, nil
+	return imagesPath, nil
 }
 
 func (f Files) WriteImage(name string, dir string, image *model.Image) (string, error) {
@@ -220,7 +235,18 @@ func (f Files) WriteImage(name string, dir string, image *model.Image) (string, 
 
 	slog.Debug("wrote", "file", filePath)
 
-	rel, err := filepath.Rel(f.DataProductsLocation, filePath)
+	var dataProductsPath string
+	if filepath.IsAbs(f.DataProductsLocation) {
+		dataProductsPath = f.DataProductsLocation
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		dataProductsPath = filepath.Join(cwd, f.DataProductsLocation)
+	}
+
+	rel, err := filepath.Rel(dataProductsPath, filePath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/validation/schema/data-structure.json
+++ b/internal/validation/schema/data-structure.json
@@ -26,7 +26,6 @@
         },
         "type": "object",
         "properties": {},
-        "required": [],
         "additionalProperties": false
       }
     },
@@ -189,7 +188,7 @@
               "description": "The text content of the button."
             }
           },
-          "required": ["buttonId", "pageUrl"],
+          "required": ["buttonId"],
           "additionalProperties": false
         },
         {


### PR DESCRIPTION
File path handling for absolute targets fixed (fingers crossed). `snowplow-cli dp download /somewhere` should now behave when generating refs.

MCP --base-directory and .env files now working together.

Minor schema example update. Example with invalid `required:` properties were confusing llms pretty badly in some cases.