### PR TITLE
[DPS-1477] Show clearer, more informative error messages when data structure validation fails

### DIFF
--- a/cmd/ds/validate.go
+++ b/cmd/ds/validate.go
@@ -28,7 +28,7 @@ var validateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := validation.ValidateDataStructuresFromCmd(cmd.Context(), cmd, args)
 		if err != nil {
-			snplog.LogFatal(errors.New("validation failed"))
+			snplog.LogFatal(errors.New("validation failed: " + err.Error()))
 		}
 	},
 }

--- a/cmd/ds/validate.go
+++ b/cmd/ds/validate.go
@@ -11,7 +11,7 @@ OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
 package ds
 
 import (
-	"errors"
+	"fmt"
 
 	snplog "github.com/snowplow/snowplow-cli/internal/logging"
 	"github.com/snowplow/snowplow-cli/internal/validation"
@@ -28,7 +28,7 @@ var validateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := validation.ValidateDataStructuresFromCmd(cmd.Context(), cmd, args)
 		if err != nil {
-			snplog.LogFatal(errors.New("validation failed: " + err.Error()))
+			snplog.LogFatal(fmt.Errorf("validation failed: %w", err))
 		}
 	},
 }


### PR DESCRIPTION
Show clearer, more informative error messages when data structure validation fails.
Example:

<img width="1982" height="165" alt="Screenshot 2025-10-08 at 9 06 33 AM" src="https://github.com/user-attachments/assets/912daed6-067d-46de-9bab-c59e2ca1c6c0" />
